### PR TITLE
Add city population markers

### DIFF
--- a/src/components/Earth/CityMarker.tsx
+++ b/src/components/Earth/CityMarker.tsx
@@ -1,0 +1,35 @@
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+
+interface CityMarkerProps {
+  name: string;
+  lat: number;
+  lon: number;
+  population: number;
+}
+
+export function CityMarker({ name, lat, lon, population }: CityMarkerProps) {
+  const radius = 1.01;
+  const phi = (90 - lat) * (Math.PI / 180);
+  const theta = (lon + 180) * (Math.PI / 180);
+
+  const position = new THREE.Vector3(
+    -(radius * Math.sin(phi) * Math.cos(theta)),
+    radius * Math.cos(phi),
+    radius * Math.sin(phi) * Math.sin(theta)
+  );
+
+  return (
+    <group position={position}>
+      <mesh>
+        <sphereGeometry args={[0.01, 8, 8]} />
+        <meshBasicMaterial color="red" />
+      </mesh>
+      <Html distanceFactor={10} position={[0, 0.02, 0]}>
+        <div className="bg-white/80 text-xs px-1 rounded whitespace-nowrap">
+          {name}: {population.toLocaleString()}
+        </div>
+      </Html>
+    </group>
+  );
+}

--- a/src/components/Earth/Earth.tsx
+++ b/src/components/Earth/Earth.tsx
@@ -3,7 +3,8 @@ import { EarthSphere } from './EarthSphere';
 import { Atmosphere } from './Atmosphere';
 import { CloudLayer } from './CloudLayer';
 import { EARTH_TEXTURES } from '../../constants/textures';
-import { LoadingScreen } from '../UI/LoadingScreen';
+import { CITIES } from '../../constants/cities';
+import { CityMarker } from './CityMarker';
 
 export function Earth() {
   const [colorMap, normalMap, specularMap, cloudsMap] = useTexture([
@@ -22,6 +23,9 @@ export function Earth() {
       />
       <Atmosphere />
       <CloudLayer cloudsMap={cloudsMap} />
+      {CITIES.map((city) => (
+        <CityMarker key={city.name} {...city} />
+      ))}
     </group>
   );
 }

--- a/src/constants/cities.ts
+++ b/src/constants/cities.ts
@@ -1,0 +1,15 @@
+export interface CityData {
+  name: string;
+  lat: number;
+  lon: number;
+  population: number;
+}
+
+export const CITIES: CityData[] = [
+  { name: 'Tokyo', lat: 35.6895, lon: 139.6917, population: 37400068 },
+  { name: 'Delhi', lat: 28.7041, lon: 77.1025, population: 29399141 },
+  { name: 'Shanghai', lat: 31.2304, lon: 121.4737, population: 26317104 },
+  { name: 'São Paulo', lat: -23.5505, lon: -46.6333, population: 21846507 },
+  { name: 'Mexico City', lat: 19.4326, lon: -99.1332, population: 21671908 },
+];
+


### PR DESCRIPTION
## Summary
- add a small city dataset
- create `CityMarker` component to show populations
- render city markers in `Earth`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_683bd8ed27c08326be3fa307b5afa5b6